### PR TITLE
fix: backport CVE-2026-27135 patch for nghttp2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+nghttp2 (1.59.0-1deepin1) unstable; urgency=medium
+
+  * Fix CVE-2026-27135: missing iframe->state validations to avoid
+    assertion failure.
+
+ -- lichenggang <lichenggang@deepin.org>  Thu, 16 Apr 2026 20:04:44 +0800
+
 nghttp2 (1.59.0-1deepin0) unstable; urgency=medium
 
   * No source change upload against GCC 12.

--- a/debian/patches/CVE-2026-27135.patch
+++ b/debian/patches/CVE-2026-27135.patch
@@ -1,0 +1,106 @@
+From 5c7df8fa815ac1004d9ecb9d1f7595c4d37f46e1 Mon Sep 17 00:00:00 2001
+From: Tatsuhiro Tsujikawa <tatsuhiro.t@gmail.com>
+Date: Wed, 18 Feb 2026 18:04:30 +0900
+Subject: [PATCH] Fix missing iframe->state validations to avoid assertion
+ failure
+
+Conflict: move nghttp2_session_mem_recv2 to nghttp2_session_mem_recv
+Reference: https://github.com/nghttp2/nghttp2/commit/5c7df8fa815ac1004d9ecb9d1f7595c4d37f46e1
+---
+ lib/nghttp2_session.c | 32 ++++++++++++++++++++++++++++++++
+ 1 file changed, 32 insertions(+)
+
+diff --git a/lib/nghttp2_session.c b/lib/nghttp2_session.c
+index ced7517..f85f46a 100644
+--- a/lib/nghttp2_session.c
++++ b/lib/nghttp2_session.c
+@@ -6031,6 +6031,10 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
+           return rv;
+         }
+ 
++        if (iframe->state == NGHTTP2_IB_IGN_ALL) {
++          return (ssize_t)inlen;
++        }
++
+         on_begin_frame_called = 1;
+ 
+         rv = session_process_headers_frame(session);
+@@ -6397,6 +6401,10 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
+           if (nghttp2_is_fatal(rv)) {
+             return rv;
+           }
++
++          if (iframe->state == NGHTTP2_IB_IGN_ALL) {
++            return (ssize_t)inlen;
++          }
+         }
+       }
+ 
+@@ -6653,6 +6661,10 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
+           return rv;
+         }
+ 
++        if (iframe->state == NGHTTP2_IB_IGN_ALL) {
++          return (ssize_t)inlen;
++        }
++
+         session_inbound_frame_reset(session);
+ 
+         break;
+@@ -6956,6 +6968,10 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
+         if (nghttp2_is_fatal(rv)) {
+           return rv;
+         }
++
++        if (iframe->state == NGHTTP2_IB_IGN_ALL) {
++          return (ssize_t)inlen;
++        }
+       } else {
+         iframe->state = NGHTTP2_IB_IGN_HEADER_BLOCK;
+       }
+@@ -7128,6 +7144,10 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
+             if (nghttp2_is_fatal(rv)) {
+               return NGHTTP2_ERR_CALLBACK_FAILURE;
+             }
++
++            if (iframe->state == NGHTTP2_IB_IGN_ALL) {
++              return (ssize_t)inlen;
++            }
+           }
+         }
+       }
+@@ -7208,6 +7228,10 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
+           return rv;
+         }
+ 
++        if (iframe->state == NGHTTP2_IB_IGN_ALL) {
++          return (ssize_t)inlen;
++        }
++
+         if (rv != 0) {
+           busy = 1;
+ 
+@@ -7226,6 +7250,10 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
+         return rv;
+       }
+ 
++      if (iframe->state == NGHTTP2_IB_IGN_ALL) {
++        return (ssize_t)inlen;
++      }
++
+       session_inbound_frame_reset(session);
+ 
+       break;
+@@ -7254,6 +7282,10 @@ ssize_t nghttp2_session_mem_recv(nghttp2_session *session, const uint8_t *in,
+         return rv;
+       }
+ 
++      if (iframe->state == NGHTTP2_IB_IGN_ALL) {
++        return (ssize_t)inlen;
++      }
++
+       session_inbound_frame_reset(session);
+ 
+       break;
+-- 
+2.43.0

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,2 +1,3 @@
 0001-Make-fetch-ocsp-response-use-python3.patch
 0002-Workaround-for-963648.patch
+CVE-2026-27135.patch


### PR DESCRIPTION
Backport upstream fix for CVE-2026-27135 which adds missing iframe->state validations in nghttp2_session_mem_recv to avoid assertion failures.